### PR TITLE
Support for specific CBOR encodings

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -30,6 +30,8 @@ pub enum Error {
     IoError(::std::io::Error),
     TrailingData,
     InvalidIndefiniteString,
+    InvalidLenPassed(len::Sz),
+    InvalidNint(i128),
 
     CustomError(String),
 }
@@ -91,7 +93,9 @@ impl fmt::Display for Error {
             IoError(_io_error) => write!(f, "Invalid cbor: I/O error"),
             TrailingData => write!(f, "Unexpected trailing data in CBOR"),
             InvalidIndefiniteString => write!(f, "Invalid cbor: Invalid indefinite string format"),
+            InvalidLenPassed(sz) => write!(f, "Invalid length for serialization: {:?}", sz),
             CustomError(err) => write!(f, "Invalid cbor: {}", err),
+            InvalidNint(x) => write!(f, "Passed nint {} out of range", x),
         }
     }
 }

--- a/src/len.rs
+++ b/src/len.rs
@@ -23,3 +23,63 @@ impl Len {
         self == &Len::Indefinite
     }
 }
+
+/// How many bytes are used in CBOR encoding for a major type/length
+#[derive(Debug, PartialEq, Eq, Copy, Clone)]
+pub enum Sz {
+    /// Length/data is encoded inside of the type information
+    Inline,
+    /// Lnegth/data is in 1 byte following the type information
+    One,
+    /// Lnegth/data is in 2 bytes following the type information
+    Two,
+    /// Lnegth/data is in 4 bytes following the type information
+    Four,
+    /// Lnegth/data is in 8 bytes following the type information
+    Eight,
+}
+
+impl Sz {
+    pub fn bytes_following(&self) -> usize {
+        match self {
+            Self::Inline => 0,
+            Self::One => 1,
+            Self::Two => 2,
+            Self::Four => 4,
+            Self::Eight => 8,
+        }
+    }
+}
+
+/// CBOR length with encoding details
+/// 
+/// Definite lengths can be encoded using a variable amount of bytes
+/// see `Sz` for more information
+#[derive(Debug, PartialEq, Eq, Copy, Clone)]
+pub enum LenSz {
+    Indefinite,
+    Len(u64, Sz),
+}
+
+impl LenSz {
+    pub fn bytes_following(&self) -> usize {
+        match self {
+            Self::Indefinite => 0,
+            Self::Len(_, sz) => sz.bytes_following(),
+        }
+    }
+}
+
+/// Encoding for the length of a string (text or bytes)
+/// 
+/// Indefinite encoding strings contain the indefinite marker followed
+/// by a series of definite encoded strings and then a break
+/// 
+/// Definite encoding strings can vary by how many bytes are used to encode
+/// the length e.g. 4 can be represented inline in the type, or in 1/2/4/8
+/// additional bytes
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub enum StringLenSz {
+    Indefinite(Vec<(u64, Sz)>),
+    Len(Sz),
+}

--- a/src/len.rs
+++ b/src/len.rs
@@ -40,6 +40,20 @@ pub enum Sz {
 }
 
 impl Sz {
+    pub fn canonical(len: u64) -> Self {
+        if len <= super::MAX_INLINE_ENCODING {
+            Sz::Inline
+        } else if len < 0x1_00 {
+            Sz::One
+        } else if len < 0x1_00_00 {
+            Sz::Two
+        } else if len < 0x1_00_00_00_00 {
+            Sz::Four
+        } else {
+            Sz::Eight
+        }
+    }
+
     pub fn bytes_following(&self) -> usize {
         match self {
             Self::Inline => 0,

--- a/src/se.rs
+++ b/src/se.rs
@@ -340,17 +340,7 @@ impl<W: Write + Sized> Serializer<W> {
     #[inline]
     fn write_type_definite(&mut self, cbor_type: Type, len: u64, sz: Option<Sz>) -> Result<&mut Self> {
         let extra_sz = match sz {
-            None => if len <= super::MAX_INLINE_ENCODING {
-                Sz::Inline
-            } else if len < 0x1_00 {
-                Sz::One
-            } else if len < 0x1_00_00 {
-                Sz::Two
-            } else if len < 0x1_00_00_00_00 {
-                Sz::Four
-            } else {
-                Sz::Eight
-            },
+            None => Sz::canonical(len),
             Some(sz) => {
                 let fits = match sz {
                     Sz::Inline => len <= super::MAX_INLINE_ENCODING,


### PR DESCRIPTION
CBOR types/lengths can be encoded inline or using 1/2/4/8 additional
bytes. This adds support to retrieve this information in deserialization
as well as provide that information during serialization.

This is very important for anyone using this library for cryptographic
purposes as these differences in CBOR encoding will result in different
bytes representing the same data, and thus different hash values.

All added APIs have the _sz suffix. Existing APIs were left alone.

Additionally the negative_integer APIs were changed to i128 instead of
i64 to represent the entire CBOR `nint` range. The existing APIs were
not changed here to avoid API breakage. Anyone interested in the entire
`nint` range should use `negative_integer_sz` and
`write_negative_integer_sz` instead.